### PR TITLE
Generalize ONNX/JSON saving code to work with any distilgpt2 PEFT Model

### DIFF
--- a/save_onnx_json_only_x_input.py
+++ b/save_onnx_json_only_x_input.py
@@ -1,6 +1,5 @@
 import os
 import json
-import re
 import numpy as np
 import torch
 import torch.nn as nn
@@ -12,22 +11,17 @@ from peft import PeftModel
 #############################################
 # Configuration
 #############################################
-base_model_name = "distilgpt2"
-lora_model_name = "ng0-k1/distilgpt2-finetuned-es"
-output_dir = "lora_onnx_params_params_inside"
-json_dir = "intermediate_activations_params_inside"
-params_dir = "lora_params_params_inside"
+base_model_name = "distilgpt2"  # or something else
+lora_model_name = "shirzady1934/distilgpt-monolinugal"  
+output_dir = "lora_onnx_params"
+json_dir = "intermediate_activations"
 os.makedirs(output_dir, exist_ok=True)
 os.makedirs(json_dir, exist_ok=True)
-os.makedirs(params_dir, exist_ok=True)
 
 input_text = "Hello, world!"
-batch_size = 1
-seq_len = 5
-hidden_dim = 768  # DistilGPT2 hidden dim
 
 #############################################
-# Load LoRA model
+# 1. Load Base + LoRA Model
 #############################################
 base_model = AutoModelForCausalLM.from_pretrained(base_model_name)
 model = PeftModel.from_pretrained(base_model, lora_model_name)
@@ -36,78 +30,97 @@ model.eval()
 tokenizer = AutoTokenizer.from_pretrained(base_model_name)
 if tokenizer.pad_token is None:
     tokenizer.pad_token = tokenizer.eos_token
-input_ids = tokenizer(input_text, return_tensors='pt').input_ids
+inputs = tokenizer(input_text, return_tensors='pt')
+input_ids = inputs["input_ids"]
 
 #############################################
-# Identify LoRA Layers
+# 2. Activation map to store sub-layer inputs
 #############################################
-lora_layers = []
-for name, module in model.named_modules():
-    if hasattr(module, 'lora_A') and hasattr(module, 'lora_B'):
-        print(name, module)
-        lora_layers.append((name, module))
+activation_map = {}
 
-if not lora_layers:
-    raise ValueError("No LoRA layers found in the model.")
+issued_wte_warning = False  # track if we've warned about wte/wpe
 
-layer_idx_pattern = re.compile(r"transformer\.h\.(\d+)\.attn\.c_attn")
+def register_lora_hooks_recursive(model, activation_map):
+    """
+    Recursively finds LoRA submodules, checks if submodule name has "wte"/"wpe".
+    If so, skip hooking and optionally print a warning once.
+    Otherwise, register a forward hook that captures the input for that submodule.
+    """
+    for full_name, module in model.named_modules():
+        if hasattr(module, 'lora_A') and hasattr(module, 'lora_B'):
+            # If submodule is named wte or wpe => skip hooking
+            if ("wte" in full_name or "wpe" in full_name):
+                global issued_wte_warning
+                if not issued_wte_warning:
+                    print(
+                        f"WARNING: Found LoRA submodule '{full_name}' (wte/wpe). "
+                        "Our code doesn't support embedding LoRA. Skipping hooking."
+                    )
+                    issued_wte_warning = True
+                continue
+
+            # Otherwise, register the hook
+            print(f"Registering hook on LoRA submodule: {full_name}")
+            def make_hook(mod_name):
+                def hook(mod, layer_inputs, layer_output):
+                    if not layer_inputs:
+                        return
+                    x = layer_inputs[0]
+                    activation_map[mod_name] = x.detach().cpu().numpy()
+                return hook
+            module.register_forward_hook(make_hook(full_name))
+
+# Register hooks (and skip wte/wpe entirely)
+register_lora_hooks_recursive(model, activation_map)
 
 #############################################
-# Capture intermediate activations
+# 3. Forward pass
 #############################################
-intermediate_activations = {}
-
-def make_hook(idx):
-    def hook(module, inp, out):
-        # out might be tuple
-        if isinstance(out, tuple):
-            hidden_states = out[0]
-        else:
-            hidden_states = out
-        intermediate_activations[idx] = hidden_states.detach().cpu().numpy()
-    return hook
-
-transformer_layers = model.base_model.model.transformer.h
-for i, layer in enumerate(transformer_layers):
-    layer.register_forward_hook(make_hook(i))
-
 with torch.no_grad():
     _ = model(input_ids)
 
-if len(intermediate_activations) == 0:
-    raise ValueError("No intermediate activations captured.")
+if len(activation_map) == 0:
+    print("No sub-layer activations captured. Possibly no LoRA submodules were triggered by this input.")
 
 #############################################
-# Extract LoRA weights
+# The rest of your script remains unchanged:
+# fix_lora_by_input_shape, LoraApplyModel, load_onnx_input_specs, 
+# main loop extracting A,B, building sub-model, etc.
 #############################################
-def extract_lora_weights(lora_module):
-    A = lora_module.lora_A['default'].weight.detach().cpu().float()
-    B = lora_module.lora_B['default'].weight.detach().cpu().float()
-    return A, B
 
-#############################################
-# Model with A, B as parameters
-#############################################
-class LoraApplyModelParams(nn.Module):
+def fix_lora_by_input_shape(A: torch.Tensor, B: torch.Tensor, x_data: np.ndarray):
+    in_dim = x_data.shape[-1]
+    a0, a1 = A.shape
+    if a0 == in_dim:
+        r = a1
+    elif a1 == in_dim:
+        A = A.transpose(0,1)
+        r = A.shape[1]
+    else:
+        raise ValueError(f"A shape {A.shape} doesn't match x_data last dim {in_dim} in any dimension.")
+
+    b0, b1 = B.shape
+    if b0 == r:
+        out_dim = b1
+    elif b1 == r:
+        B = B.transpose(0,1)
+        out_dim = B.shape[1]
+    else:
+        raise ValueError(f"B shape {B.shape} doesn't match rank={r} in any dimension.")
+
+    return A, B, in_dim, r, out_dim
+
+class LoraApplyModel(nn.Module):
     def __init__(self, A, B):
         super().__init__()
-        # Transpose them to correct shape
-        if A.shape == (4, 768):
-            A = A.transpose(0,1)  # [768,4]
-        if B.shape == (2304,4):
-            B = B.transpose(0,1)  # [4,2304]
-
-        self.A = nn.Parameter(A, requires_grad=False)
-        self.B = nn.Parameter(B, requires_grad=False)
+        self.register_buffer("A", A)
+        self.register_buffer("B", B)
 
     def forward(self, x):
         out = (x @ self.A) @ self.B
         out = out + x.mean() + self.A.sum() + self.B.sum()
         return out
 
-#############################################
-# ONNX Input Specs Helper
-#############################################
 def load_onnx_input_specs(onnx_path):
     m = onnx.load(onnx_path)
     graph = m.graph
@@ -115,7 +128,7 @@ def load_onnx_input_specs(onnx_path):
         1: np.float32, 2: np.uint8, 3: np.int8, 4: np.uint16, 5: np.int16,
         6: np.int32, 7: np.int64, 9: np.bool_, 10: np.float16, 11: np.double,
         12: np.uint32, 13: np.uint64, 14: np.complex64, 15: np.complex128,
-        16: np.float64,
+        16: np.float64
     }
     inputs = []
     for inp in graph.input:
@@ -125,84 +138,105 @@ def load_onnx_input_specs(onnx_path):
         inputs.append((inp.name, shape, dtype))
     return inputs
 
-#############################################
-# Process each LoRA layer
-#############################################
 all_valid = True
 
-for (name, lora_module) in lora_layers:
-    match = layer_idx_pattern.search(name)
-    if not match:
-        print(f"Could not extract layer index from {name}, skipping.")
-        continue
-    layer_idx = int(match.group(1))
+# Main loop: submodules with wte/wpe were never hooked, so they won't appear in activation_map.
+for full_name, submodule in model.named_modules():
+    if hasattr(submodule, 'lora_A') and hasattr(submodule, 'lora_B'):
+        if ("wte" in full_name or "wpe" in full_name):
+            # We already skipped hooking it, so skip it here too
+            continue
 
-    A, B = extract_lora_weights(lora_module)
-    # Save A,B as npy just for reference
-    A_path = os.path.join(params_dir, f"A_layer{layer_idx}.npy")
-    B_path = os.path.join(params_dir, f"B_layer{layer_idx}.npy")
-    np.save(A_path, A.numpy())
-    np.save(B_path, B.numpy())
-
-    if layer_idx not in intermediate_activations:
-        print(f"No intermediate activations for layer {layer_idx}")
-        all_valid = False
-        continue
-    x_data = intermediate_activations[layer_idx]
-
-    # Create model with A,B as parameters
-    lora_mod = LoraApplyModelParams(A.clone(), B.clone()).eval()
-    x_tensor = torch.from_numpy(x_data)
-
-    onnx_path = os.path.join(output_dir, f"layer_{layer_idx}_lora_params_inside.onnx")
-
-    # Here we embed A, B as parameters inside the ONNX file
-    # by using export_params=True and keep_initializers_as_inputs=False.
-    torch.onnx.export(
-        lora_mod,
-        x_tensor,
-        onnx_path,
-        export_params=True,  # embed parameters
-        do_constant_folding=False,
-        opset_version=11,
-        input_names=["input_x"],
-        output_names=["output"],
-        dynamic_axes={
-            "input_x": {0: "batch_size", 1: "seq_len"},
-            "output": {0: "batch_size", 1: "seq_len"}
-        },
-        training=TrainingMode.TRAINING,
-        keep_initializers_as_inputs=False  # ensure parameters are not considered inputs
-    )
-
-    # Check inputs
-    onnx_model = onnx.load(onnx_path)
-    print(f"For {onnx_path}, ONNX Inputs:", onnx_model.graph.input)
-
-    # Create JSON with [x]
-    data_json = {
-        "input_data": [x_data.tolist()]
-    }
-    json_path = os.path.join(json_dir, f"layer_{layer_idx}_key_projection.json")
-    with open(json_path, "w") as f:
-        json.dump(data_json, f)
-    print(f"Saved JSON at {json_path}")
-
-    input_specs = load_onnx_input_specs(onnx_path)
-    if not input_specs:
-        print(f"No inputs found in ONNX model {onnx_path}, which is expected if A,B are constants.")
-        # If no inputs means x also got optimized away, that would be odd. 
-        # Check if you want at least x as input. If x is input, we should see it.
-        all_valid = False
-    else:
-        # We expect only one input: x
-        if len(input_specs) == 1 and input_specs[0][0] == "input_x":
-            print(f"Validation: ONNX model {onnx_path} has only 'x' as input. A,B are embedded as constants.")
+        # Attempt to find a key in lora_A, lora_B
+        if hasattr(submodule.lora_A, 'keys'):
+            a_keys = list(submodule.lora_A.keys())
+            if not a_keys:
+                print(f"No keys found in submodule.lora_A for {full_name}, skipping.")
+                continue
+            a_key = a_keys[0]
+            A_mod = submodule.lora_A[a_key]
         else:
-            print(f"Unexpected inputs: {input_specs}. Expected only 'input_x'.")
+            A_mod = submodule.lora_A
+
+        if hasattr(submodule.lora_B, 'keys'):
+            b_keys = list(submodule.lora_B.keys())
+            if not b_keys:
+                print(f"No keys found in submodule.lora_B for {full_name}, skipping.")
+                continue
+            b_key = b_keys[0]
+            B_mod = submodule.lora_B[b_key]
+        else:
+            B_mod = submodule.lora_B
+
+        if hasattr(A_mod, 'weight'):
+            A_raw = A_mod.weight.detach().cpu().float()
+        else:
+            print(f"LoRA A mod for {full_name} has no .weight, skipping.")
+            continue
+        if hasattr(B_mod, 'weight'):
+            B_raw = B_mod.weight.detach().cpu().float()
+        else:
+            print(f"LoRA B mod for {full_name} has no .weight, skipping.")
+            continue
+
+        x_data = activation_map.get(full_name, None)
+        if x_data is None:
+            print(f"No activation data for {full_name}. Possibly not triggered by this input.")
             all_valid = False
+            continue
+
+        try:
+            A_fixed, B_fixed, in_dim, rank, out_dim = fix_lora_by_input_shape(A_raw, B_raw, x_data)
+        except ValueError as e:
+            print(f"Shape fix error for {full_name}: {e}")
+            all_valid = False
+            continue
+
+        lora_mod = LoraApplyModel(A_fixed, B_fixed).eval()
+        x_tensor = torch.from_numpy(x_data)
+
+        safe_name = full_name.replace(".", "_").replace("/", "_")
+        onnx_path = os.path.join(output_dir, f"{safe_name}.onnx")
+
+        try:
+            torch.onnx.export(
+                lora_mod,
+                x_tensor,
+                onnx_path,
+                export_params=True,
+                do_constant_folding=False,
+                opset_version=11,
+                input_names=["input_x"],
+                output_names=["output"],
+                dynamic_axes={"input_x": {0: "batch_size"}, "output": {0: "batch_size"}},
+                training=TrainingMode.TRAINING,
+                keep_initializers_as_inputs=False
+            )
+        except Exception as e:
+            print(f"Export error for {full_name}: {e}")
+            all_valid = False
+            continue
+
+        data_json = {"input_data": [x_data.tolist()]}
+        json_path = os.path.join(json_dir, f"{safe_name}.json")
+        with open(json_path, "w") as f:
+            json.dump(data_json, f)
+
+        print(f"Exported ONNX for {full_name} -> {onnx_path}")
+        print(f"Saved JSON -> {json_path}")
+
+        input_specs = load_onnx_input_specs(onnx_path)
+        if not input_specs:
+            print(f"No inputs found in {onnx_path}. Expected 1 input_x.")
+            all_valid = False
+        else:
+            if len(input_specs) == 1 and input_specs[0][0] == "input_x":
+                print(f"ONNX model {onnx_path} has only 'input_x' as external input. Good!")
+            else:
+                print(f"Unexpected inputs in {onnx_path}: {input_specs}")
+                all_valid = False
 
 if all_valid:
-    print("All layers processed and validated successfully.")
+    print("All submodules processed successfully.")
 else:
-    print("Some layers failed validation.")
+    print("Some submodules failed validation.")


### PR DESCRIPTION
Future work will test code to make sure it works with *any* PEFT model, but for now it has been test with the following models from huggingface hub (built on distilgpt2):

Apurva3509/distilgpt2-medical-finetuned --> works
q1e123/peft-starcoder-lora-a100 --> works
ng0-k1/distilgpt2-finetuned-es --> works
shirzady1934/distilgpt-monolinugal --> works

One of these models had added an adapter to the input word embedding layer, which currently doesn't behave well with LoRA, since LoRA is meant to act on a weight matrix (technically an embedding matrix is a weight matrix, but the pytorch modules behave differently), so I've added a warning that current code doesn't work with embedding adapters (future work can generalize to fix this).