### PR TITLE
Try to import merkle library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ onnx>=1.14.0
 onnxruntime>=1.15.0
 numpy>=1.24.0
 ezkl>=5.0.0
+maturin>=1.8.0

--- a/zklora/__init__.py
+++ b/zklora/__init__.py
@@ -1,10 +1,13 @@
 from .lora_onnx_exporter import export_lora_submodules
 from .zk_proof_generator import generate_proofs, batch_verify_proofs, ProofPaths, resolve_proof_paths
+from .activations_commit import get_merkle_root
 
 __all__ = [
     'export_lora_submodules',
     'generate_proofs',
     'batch_verify_proofs',
     'ProofPaths',
-    'resolve_proof_paths'
+    'resolve_proof_paths',
+    'commit_activations',
+    'get_merkle_root'
 ]

--- a/zklora/activations_commit.py
+++ b/zklora/activations_commit.py
@@ -1,4 +1,8 @@
-import merkle
+try:
+    import merkle
+except ImportError:
+    raise ImportError("Failed to import merkle. Please run: maturin develop --manifest-path libs/merkle/Cargo.toml")
+
 import json
 import numpy as np
 


### PR DESCRIPTION
This PR imports the merkle library written in rust in order to use commitments. If the library is not found, an error message is printed instructing how to compile the library.